### PR TITLE
[BT-5143] Fix interpolated string in seed data

### DIFF
--- a/sample-app/Services/SeedService.cs
+++ b/sample-app/Services/SeedService.cs
@@ -24,7 +24,7 @@ public static class SeedService
                                         {name: 'books'},
                                         {name: 'movies'}
                                       ].map(c => {
-                                        Category.byName(c.name).first() ?? Category.create({ name: c.name, description: 'Bargain #{c.name}!' })
+                                        Category.byName(c.name).first() ?? Category.create({ name: c.name, description: "Bargain #{c.name}!" })
                                       })
 
                                       // Force empty return


### PR DESCRIPTION
**Problem:** Category descriptions include a literal `#{c.name}`. 

**Solution:** Double-quote the string. Only double-quoted strings support interpolation in FQL.