### PR TITLE
[DOCS-3445] Remove `.fauna-project`

### DIFF
--- a/.fauna-project
+++ b/.fauna-project
@@ -1,6 +1,0 @@
-schema_directory=./schema
-default=dev
-
-[environment.dev]
-endpoint=cloud-us
-database=EcommerceDotnet

--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ docs](https://docs.fauna.com/fauna/current/tools/shell/).
 
 ## Setup
 
-1. In your terminal, clone the repo and navigate to the `dotnet-sample-app`
-   directory. For example:
+1. Clone the repo and navigate to the `dotnet-sample-app` directory:
 
     ```sh
     git clone git@github.com:fauna/dotnet-sample-app.git
@@ -92,20 +91,20 @@ docs](https://docs.fauna.com/fauna/current/tools/shell/).
     git submodule init && git submodule update
     ```
 
-    The repo includes a
-   [`.fauna-project`](https://docs.fauna.com/fauna/current/tools/shell/#proj-config)
-   file that contains defaults for the Fauna CLI. The file indicates:
-
-    - `EcommerceDotnet` is the default database for the project.
-
-    - The project stores Fauna Schema Language (FSL) files in the
-      `schema` directory.
-
 2. Log in to Fauna using the Fauna CLI:
 
     ```sh
     fauna cloud-login
     ```
+
+    When prompted, enter:
+
+      * **Endpoint name:** `cloud` (Press Enter)
+      * **Email address:** The email address for your Fauna account.
+      * **Password:** The password for your Fauna account.
+      * **Which endpoint would you like to set as default?** The `cloud-*`
+        endpoint for your preferred region group. For example, to use the US
+        region group, use `cloud-us`.
 
     The command requires an email and password login. If you log in to the Fauna
     using GitHub or Netlify, you can enable email and password login using the
@@ -118,7 +117,23 @@ docs](https://docs.fauna.com/fauna/current/tools/shell/).
     fauna create-database --environment='' EcommerceDotnet
     ```
 
-4.  Push the FSL files in the `schema` directory to the `EcommerceDotnet`
+4. Create a
+   [`.fauna-project`](https://docs.fauna.com/fauna/current/tools/shell/#proj-config)
+   config file for the project:
+
+   ```sh
+   fauna project init
+   ```
+
+   When prompted, enter:
+
+    * `schema` as the schema directory.
+    * `dev` as the environment name.
+    * The default endpoint.
+    * `EcommerceDotnet` as the database.
+
+
+5.  Push the FSL files in the `schema` directory to the `EcommerceDotnet`
     database:
 
     ```sh
@@ -129,7 +144,7 @@ docs](https://docs.fauna.com/fauna/current/tools/shell/).
     and user-defined functions (UDFs) defined in the FSL files of the
     `schema` directory.
 
-5. Create a key with the `server` role for the `EcommerceDotnet` database:
+6. Create a key with the `server` role for the `EcommerceDotnet` database:
 
     ```sh
     fauna create-key --environment='' EcommerceDotnet server
@@ -138,13 +153,13 @@ docs](https://docs.fauna.com/fauna/current/tools/shell/).
     Copy the returned `secret`. The app can use the key's secret to authenticate
     requests to the database.
 
-6. Make a copy of the `.env.example` file and name the copy `.env`. For example:
+7. Make a copy of the `.env.example` file and name the copy `.env`. For example:
 
     ```sh
     cp .env.example .env
     ```
 
-7.  In `.env`, set the `FAUNA_SECRET` environment variable to the secret you
+8.  In `.env`, set the `FAUNA_SECRET` environment variable to the secret you
     copied earlier:
 
     ```


### PR DESCRIPTION
**Problem:** The app contains a `.fauna-project` file that defaults to the `cloud-us` endpoint. This can conflict with the default endpoint set using `cloud-login`.

**Solution:** Remove the `.fauna-project` file and add a step for creating `.fauna-project` using `project init`.