### PR TITLE
docs: Note minimum fauna-shell vers

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,12 @@ To run the app, you'll need:
 
 - .NET 6.0 or later.
 
-- The [Fauna CLI](https://docs.fauna.com/fauna/current/tools/shell/). To install
-  the CLI, run:
+- [Fauna CLI](https://docs.fauna.com/fauna/current/tools/shell/) v3.0.0 or later.
+
+  To install the CLI, run:
 
     ```sh
-    npm install -g fauna-shell
+    npm install -g fauna-shell@latest
     ```
 
 You should also be familiar with basic Fauna CLI commands and usage. For an


### PR DESCRIPTION
Notes the minimum required Fauna CLI version. Setup uses staged schema commands, which require fauna-shell v3.0.0 or later.

Port of https://github.com/fauna/js-sample-app/pull/61