### PR TITLE
docs: CLI v4 is now GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ To run the app, you'll need:
 
 - .NET 8.0 or later.
 
-- [Fauna CLI v4 beta](https://docs.fauna.com/fauna/current/build/cli/v4/) or later.
+- [Fauna CLI v4](https://docs.fauna.com/fauna/current/build/cli/v4/).
     - [Node.js](https://nodejs.org/en/download/) v20.x or later.
 
   To install the CLI, run:
 
     ```sh
-    npm install -g fauna-shell@">=4.0.0-beta"
+    npm install -g fauna-shell
     ```
 
 ## Setup


### PR DESCRIPTION
Updates the README to indicate that v4 of the Fauna CLI is now GA.