### PR TITLE
docs: README: Bump recommended CLI v4 Node vers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ To run the app, you'll need:
 - .NET 8.0 or later.
 
 - [Fauna CLI v4 beta](https://docs.fauna.com/fauna/current/build/cli/v4/) or later.
-    - [Node.js](https://nodejs.org/en/download/) v22.x or later.
+    - [Node.js](https://nodejs.org/en/download/) v20.18 or later.
+      - [Node.js](https://nodejs.org/en/download/) v22 or later recommended.
 
   To install the CLI, run:
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To run the app, you'll need:
 - .NET 8.0 or later.
 
 - [Fauna CLI v4 beta](https://docs.fauna.com/fauna/current/build/cli/v4/) or later.
-    - [Node.js](https://nodejs.org/en/download/) v20.x or later.
+    - [Node.js](https://nodejs.org/en/download/) v22.x or later.
 
   To install the CLI, run:
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To run the app, you'll need:
 3. Use the Fauna CLI to create the `EcommerceDotnet` database:
 
     ```sh
-    # Replace 'us' with your preferred Region Group:
+    # Replace 'us' with your preferred region group:
     # 'us' (United States), 'eu' (Europe), or `global` (available to Pro accounts and above).
     fauna database create \
       --name EcommerceDotnet \
@@ -107,7 +107,7 @@ To run the app, you'll need:
     database:
 
     ```sh
-    # Replace 'us' with your Region Group identifier.
+    # Replace 'us' with your region group identifier.
     fauna schema push \
       --database us/EcommerceDotnet
     ```


### PR DESCRIPTION
## Problem
Two unrelated changes (bundling cause it's just README):

* Per https://github.com/fauna/fauna-shell/pull/579, we recently bumped Node versions for CLI v4:
  * Required: v20.18 or later
  * Recommended: v22 or later
* We recently aligned with marketing to use sentence case for several feature names, including "Region Group."

## Solution

Updates the README.